### PR TITLE
Fix steam auth

### DIFF
--- a/omniauth-steam.rb
+++ b/omniauth-steam.rb
@@ -13,7 +13,7 @@ module OmniAuth
 
       option :api_key, nil
       option :name, "steam"
-      option :identifier, "http://steamcommunity.com/openid"
+      option :identifier, "https://steamcommunity.com/openid"
 
       uid { steam_id }
 
@@ -49,11 +49,11 @@ module OmniAuth
       end
 
       def player_profile_uri
-        URI.parse("http://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key=#{options.api_key}&steamids=#{steam_id}")
+        URI.parse("https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key=#{options.api_key}&steamids=#{steam_id}")
       end
 
       def friend_list_url
-        URI.parse("http://api.steampowered.com/ISteamUser/GetFriendList/v0001/?key=#{options.api_key}&steamid=#{steam_id}&relationship=friend")
+        URI.parse("https://api.steampowered.com/ISteamUser/GetFriendList/v0001/?key=#{options.api_key}&steamid=#{steam_id}&relationship=friend")
       end
     end
   end


### PR DESCRIPTION
About a year ago, steam silently changed their OpenID to only accept HTTPS requests.