### PR TITLE
Add 'allow revoke' setting

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2,6 +2,7 @@ en:
   site_settings:
     enable_steam_logins: "Enable Steam authentication, requires steam_web_api_key. See <a href='https://meta.discourse.org/t/18153' target='_blank'>Steam Login / Authentication Plugin</a>"
     steam_web_api_key: "Steam web API key"
+    steam_allow_revoke: "Allow users to unlink their Steam account"
 
     errors:
       steam_web_api_key_is_empty: "You must set 'steam web api key' before enabling this setting."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,3 +5,5 @@ plugins:
   steam_web_api_key:
     default: ""
     secret: true
+  steam_allow_revoke:
+    default: true

--- a/lib/auth/steam_authenticator.rb
+++ b/lib/auth/steam_authenticator.rb
@@ -9,6 +9,10 @@ class Auth::SteamAuthenticator < ::Auth::ManagedAuthenticator
     SiteSetting.enable_steam_logins
   end
 
+  def can_revoke?
+    SiteSetting.steam_allow_revoke
+  end
+
   def register_middleware(omniauth)
     omniauth.provider :steam, setup: lambda { |env|
       strategy = env["omniauth.strategy"]


### PR DESCRIPTION
Added a simple config entry to control whether users can unlink their Steam accounts. This is widely used in gaming communities as the only sign up and log in method (moreover you got a request in plugin's Discourse discussion) so I guess this will be a very useful. It won't break existing installations as default behavior is set by default