### PR TITLE
DEV: resolve Rails/ReversibleMigrationMethodDefinition errors

### DIFF
--- a/db/migrate/20190510055357_migrate_steam_auth_data.rb
+++ b/db/migrate/20190510055357_migrate_steam_auth_data.rb
@@ -19,4 +19,8 @@ class MigrateSteamAuthData < ActiveRecord::Migration[5.2]
     WHERE plugin_name = 'steam'
     SQL
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end


### PR DESCRIPTION
We are adding the Rails/ReversibleMigrationMethodDefinition cop to rubocop-discourse, this change resolves existing errors under this rule.