### PR TITLE
FIX: Add `/gems` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+/gems
+/auto_generated


### PR DESCRIPTION
We got this issue in this [pr](https://github.com/discourse/discourse-steam-login/pull/95)

Where it would commit the `/gems`